### PR TITLE
Github-REDME theme pre tag overflow 

### DIFF
--- a/CSS/GitHub-ReadMe.css
+++ b/CSS/GitHub-ReadMe.css
@@ -5,7 +5,7 @@ URL: https://github.com/hzlzh/Mou-Theme
 */
 @charset "UTF-8";
 body, input, select, textarea, button{ font:13px/1.4 Helvetica, arial, freesans, clean, sans-serif; color:#333333; }
-body{ background-color:#FFFFFF; color:#333333; background-color:#FFFFFF; border:3px solid #EEEEEE; padding:0 30px 30px; font-size:15px; line-height:1.7; margin:20px auto; max-width:722px;margin-left: 10px; border-radius:3px 3px 3px 3px; }
+body{ background-color:#FFFFFF; color:#333333; background-color:#FFFFFF; border:3px solid #EEEEEE; padding:0 30px 30px; font-size:15px; line-height:1.7; max-width:722px; margin:5px; border-radius:3px 3px 3px 3px; }
 a{ color:#4183C4; text-decoration:none; }
 a:hover{ text-decoration:underline; }
 a:focus, a:active{ text-decoration:underline; }


### PR DESCRIPTION
Pre tag is block element.
When width: 100% and padding: 6px 10px; came up together, it would overflow.
